### PR TITLE
Potential fix for code scanning alert no. 50: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,16 @@ name: .NET Continuous Deployment
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   test:
     name: SharedCode Test
     runs-on: windows-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v3
 
@@ -23,6 +28,8 @@ jobs:
     needs: test
     name: Create a Package Release
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v3
 
@@ -57,6 +64,8 @@ jobs:
     needs: semantic-release
     name: Publish to Github
     runs-on: windows-latest
+    permissions:
+      packages: write
     steps:
     - name: Download built project
       uses: actions/download-artifact@v4.1.8
@@ -75,6 +84,8 @@ jobs:
     needs: semantic-release
     name: Publish to Nuget
     runs-on: windows-latest
+    permissions:
+      packages: write
     steps:
     - name: Download built project
       uses: actions/download-artifact@v4.1.8


### PR DESCRIPTION
Potential fix for [https://github.com/improvgroup/sharedcode/security/code-scanning/50](https://github.com/improvgroup/sharedcode/security/code-scanning/50)

To fix the issue, we will add a `permissions` block to the root of the workflow and to individual jobs where necessary. This ensures that each job has the minimum required permissions for its tasks. For example:
- The `test` job does not require any write permissions, so it will be limited to `contents: read`.
- The `semantic-release` job requires write permissions for `contents` to create tags and releases.
- The `github-publish` and `nuget-publish` jobs require `packages: write` to push packages.

We will add these permissions explicitly to the workflow and jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
