### PR TITLE
Potential fix for code scanning alert no. 46: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -17,6 +17,9 @@
 # Read the official documentation here : https://learn.microsoft.com/en-us/azure/defender-for-cloud/quickstart-onboard-github
 
 name: "Microsoft Defender For Devops"
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/improvgroup/sharedcode/security/code-scanning/46](https://github.com/improvgroup/sharedcode/security/code-scanning/46)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for accessing the repository's contents.
- `security-events: write` for uploading SARIF results to the Security tab.

The `permissions` block will be added immediately after the `name` field in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
