### PR TITLE
Potential fix for code scanning alert no. 45: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,8 @@
 name: .NET Continuous Integration
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/improvgroup/sharedcode/security/code-scanning/45](https://github.com/improvgroup/sharedcode/security/code-scanning/45)

To fix the issue, add a `permissions` block to the workflow. Since the workflow only runs tests and does not require write access, the permissions can be limited to `contents: read`. This block should be added at the root level of the workflow to apply to all jobs, as there is no indication that any job requires additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
